### PR TITLE
ref(state+notification): send StateEvents enum through channel

### DIFF
--- a/src/store/state/app_state.rs
+++ b/src/store/state/app_state.rs
@@ -1,0 +1,30 @@
+use crate::store::{
+    accounts::Accounts,
+    action_manager::ActionManager,
+    explorer::Explorer,
+    notifications::{types::Notification, Notifications},
+    sources::Sources,
+};
+
+#[derive(Default, Debug, Clone)]
+pub enum DashboardComponents {
+    Sources,
+    #[default]
+    Accounts,
+    Explorer,
+}
+
+#[derive(Debug, Clone)]
+pub struct AppState {
+    pub sources: Sources,
+    pub accounts: Accounts,
+    pub explorer: Explorer,
+    pub action_manager: ActionManager,
+    pub notifications: Notifications,
+    pub selected_component: DashboardComponents,
+}
+
+pub enum StateEvents {
+    UpdateState(AppState),
+    Alert(Notification),
+}

--- a/src/tui/screens/dashboard.rs
+++ b/src/tui/screens/dashboard.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::{
     action::Action,
     store::{
+        notifications::types::Notification,
         sources::WithSources,
         state::{AppState, DashboardComponents},
     },
@@ -55,6 +56,9 @@ impl Dashboard {
             aside_constraints: [Constraint::Length(3), Constraint::Fill(1)],
         }
     }
+    pub fn handle_alert(&mut self, alert: Notification) {
+        self.notifications.set_alert(Some(alert));
+    }
     pub fn refresh_components(self, state: &AppState) -> Self {
         let sources = Sources::new(
             state.sources.get_available_sources(),
@@ -74,7 +78,7 @@ impl Dashboard {
             self.ui_tx.clone(),
         );
 
-        let notifications = NotificationsUI::new(state.notifications.clone(), self.ui_tx.clone());
+        let notifications = self.notifications.refresh(state.notifications.clone());
         let aside_constraints =
             if matches!(&state.selected_component, &DashboardComponents::Accounts) {
                 [Constraint::Length(3), Constraint::Fill(1)]

--- a/src/tui/sections/notifications.rs
+++ b/src/tui/sections/notifications.rs
@@ -7,13 +7,16 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    store::notifications::{types::NotificationType, Notifications},
+    store::notifications::{
+        types::{Notification, NotificationType},
+        Notifications,
+    },
     tui::components::traits::{Component, ComponentProps, WithContainer},
 };
 
 pub struct NotificationsUI {
     notifications: Notifications,
-    alert_visible: bool,
+    alert: Option<Notification>,
     ui_tx: UnboundedSender<Action>,
 }
 
@@ -21,12 +24,20 @@ impl NotificationsUI {
     pub fn new(notifications: Notifications, ui_tx: UnboundedSender<Action>) -> NotificationsUI {
         NotificationsUI {
             notifications,
-            alert_visible: false,
             ui_tx,
+            alert: None,
         }
     }
+    pub fn refresh(mut self, notifications: Notifications) -> Self {
+        self.notifications = notifications;
+        self
+    }
     pub fn has_visible_alert(&self) -> bool {
-        self.alert_visible
+        self.alert.is_some()
+    }
+
+    pub fn set_alert(&mut self, alert: Option<Notification>) {
+        self.alert = alert;
     }
 }
 
@@ -43,52 +54,46 @@ impl Component for NotificationsUI {
             .borders(Borders::ALL)
             .title("Notifications")
             .border_type(BorderType::Rounded);
-        if let Some(notification) = self.notifications.get_last() {
-            match notification {
-                NotificationType::Notification(notification) => {
-                    let inner_container = container.inner(area);
-                    let style = if notification.has_error() {
-                        Style::default().fg(Color::Red)
-                    } else {
-                        Style::default().fg(Color::LightGreen)
-                    };
-                    let notification_text = Paragraph::new(notification.get_message()).style(style);
-                    f.render_widget(notification_text, inner_container);
-                    self.alert_visible = false;
-                }
-                NotificationType::Alert(notification) if !notification.has_been_shown() => {
-                    self.alert_visible = true;
-                    let layout = Layout::default()
-                        .direction(Direction::Vertical)
-                        .constraints([
-                            Constraint::Fill(1),
-                            Constraint::Fill(2),
-                            Constraint::Fill(1),
-                        ])
-                        .split(f.size());
-                    let center_section = Layout::default()
-                        .direction(Direction::Horizontal)
-                        .constraints([
-                            Constraint::Fill(2),
-                            Constraint::Fill(1),
-                            Constraint::Fill(2),
-                        ])
-                        .margin(1)
-                        .split(layout[1])[1];
+        if let Some(alert) = &self.alert {
+            let layout = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Fill(1),
+                    Constraint::Fill(2),
+                    Constraint::Fill(1),
+                ])
+                .split(f.size());
+            let center_section = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([
+                    Constraint::Fill(2),
+                    Constraint::Fill(1),
+                    Constraint::Fill(2),
+                ])
+                .margin(1)
+                .split(layout[1])[1];
 
-                    let notification_text = Paragraph::new(notification.get_message())
-                        .block(container.clone())
-                        .wrap(Wrap::default())
-                        .style(Style::default().fg(Color::Red));
-                    f.render_widget(Clear, center_section);
-                    f.render_widget(notification_text, center_section);
-                }
-                _ => self.alert_visible = false,
-            };
+            let notification_text = Paragraph::new(alert.get_message())
+                .block(container.clone())
+                .wrap(Wrap::default())
+                .style(Style::default().fg(Color::Red));
+            f.render_widget(Clear, center_section);
+            f.render_widget(notification_text, center_section);
         }
+        if let Some(NotificationType::Notification(notification)) = self.notifications.get_last() {
+            let inner_container = container.inner(area);
+            let style = if notification.has_error() {
+                Style::default().fg(Color::Red)
+            } else {
+                Style::default().fg(Color::LightGreen)
+            };
+            let notification_text = Paragraph::new(notification.get_message()).style(style);
+            f.render_widget(notification_text, inner_container);
+        };
         f.render_widget(container, area);
     }
     fn handle_key_events(&mut self, _key: crossterm::event::KeyEvent) {
-        self.ui_tx.send(Action::DismissLastAlert);
+        self.alert = None;
+        let _ = self.ui_tx.send(Action::DismissLastAlert);
     }
 }


### PR DESCRIPTION
This allows for partial update of components, and, for notifications, the display of an alert when needed