### PR TITLE
fix(explorer): avoid creating new component when using explorer

### DIFF
--- a/src/tui/screens/dashboard.rs
+++ b/src/tui/screens/dashboard.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::{
     action::Action,
     store::{
+        explorer::{FileTree, Folder},
         notifications::types::Notification,
         state::{ui_state::UIState, DashboardComponents},
     },
@@ -61,6 +62,11 @@ impl Dashboard {
     pub fn handle_alert(&mut self, alert: Notification) {
         self.notifications.set_alert(Some(alert));
     }
+
+    pub fn refresh_explorer(&mut self, file_tree: FileTree, selected_folder: Option<Folder>) {
+        self.explorer.refresh(file_tree, selected_folder);
+    }
+
     pub fn refresh_components(mut self, state: &UIState) -> Self {
         let sources = Sources::new(
             &state.sources.available_sources,
@@ -74,10 +80,14 @@ impl Dashboard {
             &state.accounts.active_account,
             self.ui_tx.clone(),
         );
-        let explorer = Explorer::new(
-            Some(state.explorer.file_tree.clone()),
+        // let explorer = Explorer::new(
+        //     Some(state.explorer.file_tree.clone()),
+        //     state.explorer.selected_folder.clone(),
+        //     self.ui_tx.clone(),
+        // );
+        self.explorer.refresh(
+            state.explorer.file_tree.clone(),
             state.explorer.selected_folder.clone(),
-            self.ui_tx.clone(),
         );
 
         self.notifications.refresh(state.notifications.clone());
@@ -93,7 +103,7 @@ impl Dashboard {
             selected_component: state.selected_component.clone(),
             sources,
             accounts,
-            explorer,
+            explorer: self.explorer,
             notifications: self.notifications,
             hints,
             ui_tx: self.ui_tx,

--- a/src/tui/sections/explorer.rs
+++ b/src/tui/sections/explorer.rs
@@ -85,6 +85,35 @@ impl Explorer {
             listeners: Self::register_listeners(),
         }
     }
+
+    pub fn refresh(&mut self, file_tree: FileTree, selected_folder: Option<Folder>) {
+        let file_tree_vec = file_tree
+            .tree_to_vec()
+            .into_iter()
+            .filter(|tree_item| {
+                if let TreeItem::Folder(folder, _) = tree_item {
+                    return folder.name != *"/";
+                }
+                true
+            })
+            .collect::<Vec<TreeItem>>();
+        self.file_tree = file_tree_vec;
+
+        let current_folder_idx = selected_folder.and_then(|val| {
+            self.file_tree.iter().position(|tree_item| {
+                if let TreeItem::Folder(folder, _) = tree_item {
+                    *folder.name == val.name
+                } else {
+                    false
+                }
+            })
+        });
+
+        if current_folder_idx.is_some() {
+            self.current_folder_idx = current_folder_idx;
+        }
+    }
+
     pub fn set_active_idx(&mut self, active_idx: Option<usize>) {
         self.current_folder_idx = active_idx;
     }


### PR DESCRIPTION
Might not be optimal but works for now, refresh file_tree and keeps list position when closing folder